### PR TITLE
Update rbi to permit Data.define without arguments

### DIFF
--- a/rbi/core/data.rbi
+++ b/rbi/core/data.rbi
@@ -123,13 +123,12 @@ class Data < Object
   # ```
   sig do
     params(
-        arg0: T.any(Symbol, String),
-        arg1: T.any(Symbol, String),
+        args: T.any(Symbol, String),
         blk: T.untyped,
     )
     .returns(Data)
-  end
-  def self.define(arg0, *arg1, &blk); end
+  ens
+  def self.define(*args, &blk); end
 
   # Returns an array of member names of the data class:
   #

--- a/rbi/core/data.rbi
+++ b/rbi/core/data.rbi
@@ -127,7 +127,7 @@ class Data < Object
         blk: T.untyped,
     )
     .returns(Data)
-  ens
+  end
   def self.define(*args, &blk); end
 
   # Returns an array of member names of the data class:

--- a/test/testdata/rbi/data.rb
+++ b/test/testdata/rbi/data.rb
@@ -1,7 +1,7 @@
 # typed: true
 
 class Define
-  Data.define # error: Not enough arguments provided for method `Data.define`. Expected: `1+`, got: `0`
+  Data.define
   Data.define(:x, :y)
   Data.define("x", "y")
 
@@ -10,9 +10,14 @@ class Define
   end
 end
 
+NotFound = Data.define
 Point = Data.define(:x, :y)
 
 class ValidInitializers
+  T.assert_type!(NotFound, T.class_of(NotFound))
+  not_found = NotFound.new
+  T.assert_type!(notfound, NotFound)
+  
   T.assert_type!(Point, T.class_of(Point))
 
   point = Point.new(1, 2)


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->
`Data.define()` can be called (with no args) to create a class. Line 104 of this file has an example, `NotFound`.

I have never used rbi before so this PR may contain obvious errors or misunderstandings.

### Motivation
I tried to add Sorbet to a project and immediately ran into an incorrect error from `srb tc`: 

```
Not enough arguments provided for method `Data.define`. Expected: `1+`, got: `0`
```

### Test plan
I have attempted to update the appropriate test via GitHub, but I don't know how to run them.